### PR TITLE
Bug fix for server.js

### DIFF
--- a/js-server/server.js
+++ b/js-server/server.js
@@ -17,7 +17,7 @@ server.on('connection', function(client) {
     client.on('stream', function(stream, meta) {
         console.log("Stream Start")
         var fileName = "recordings/"+ new Date().getTime()  + ".wav"
-        var fileWriter = new wav.FileWriter(fileName, {
+        fileWriter = new wav.FileWriter(fileName, {
             channels: 1,
             sampleRate: 44100,
             bitDepth: 16


### PR DESCRIPTION
The code declares a new vaiabler filewriter on the client streaming event. This creates an error in the process of closing the writing process of the wav file. We have 2 "filewriter" variables in 2 different scopes. I suggest a correction on line 20 to avoid the closing problems.
